### PR TITLE
Constellation node needs to wait for tm.conf to be generated

### DIFF
--- a/constellation/start.sh
+++ b/constellation/start.sh
@@ -10,5 +10,15 @@ set -e
 ### Configuration Options
 TMCONF=/qdata/constellation/tm.conf
 
+#
+# we cannot start until tm.conf is available
+#
+echo "[*] TMCONF=$TMCONF"
+while [ ! -f $TMCONF ]
+do
+  sleep 2
+done
+
 echo "[*] Starting Constellation node"
 nohup /usr/local/bin/constellation-node $TMCONF -v3 2>>/qdata/logs/constellation.log
+


### PR DESCRIPTION
The geth node waits for its data to be initialized, but the constellation node attempts to start straight away.
This causes it to go into a crash-recycle loop, which prevents the pod becoming healthy, which prevents initialization (which would make constellation happy).