### PR TITLE
fx: run quorum/constellation as PID 1

### DIFF
--- a/constellation/start.sh
+++ b/constellation/start.sh
@@ -13,5 +13,5 @@ node /usr/local/src/index.js --constellation
 TMCONF=/qdata/constellation/tm.conf
 
 echo "[*] Starting Constellation node"
-nohup constellation-node $TMCONF -v3 2>>/qdata/logs/constellation.log
+exec nohup constellation-node $TMCONF -v3 2>>/qdata/logs/constellation.log
 

--- a/geth/start.sh
+++ b/geth/start.sh
@@ -37,4 +37,4 @@ fi
 
 echo "[*] Starting node with args $GETH_ARGS"
 export PRIVATE_CONFIG=/qdata/constellation/tm.conf
-nohup sh -c "geth $GETH_ARGS" 2>>/qdata/logs/geth.log
+exec nohup geth $GETH_ARGS 2>>/qdata/logs/geth.log


### PR DESCRIPTION
This change makes quorum and constellation subsume the bash process the fires them off so that quorum/constellation can consume the SIGTERM signal sent from docker directly.

Before the change docker was forcefully killing containers after a timeout:
```
be5fb47ff65c        jpmorganchase/quorum           "start.sh --bootnode…"   43 seconds ago       Exited (137) 21 seconds ago                         node_3
58005bfa13bb        jpmorganchase/quorum           "start.sh --bootnode…"   43 seconds ago       Exited (137) 21 seconds ago                         node_1
d52b09736b6c        jpmorganchase/quorum           "start.sh --bootnode…"   43 seconds ago       Exited (137) 21 seconds ago                         node_2
6d58b95e5a41        jpmorganchase/constellation    "/usr/local/bin/star…"   44 seconds ago       Exited (137) 10 seconds ago                         constellation_3
934fe549ee2a        jpmorganchase/constellation    "/usr/local/bin/star…"   44 seconds ago       Exited (137) 10 seconds ago                         constellation_1
c6b5623f320f        jpmorganchase/quorum           "bootnode -nodekey /…"   44 seconds ago       Exited (2) 20 seconds ago                           bootnode
abe3d8e9d7b1        jpmorganchase/constellation    "/usr/local/bin/star…"   44 seconds ago       Exited (137) 10 seconds ago                         constellation_2
```

After the change, we can see the PID 1s point at the correct processes in the containers:

```
root@eab01f29fd10:/# ps -aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  4.8 15.7 991272 322392 ?       Ssl  19:47   0:01 geth --datadir /qdata/ethereum --nodekey /qdata_decrypted/ethereum/nodekey --targetgaslimit 804247552 --gasprice 0 --txpool.pricelimit 0 --rpc --rpcport 8545 --rpcaddr 0.0.0
root        38  1.5  0.1  18240  3076 pts/0    Ss   19:48   0:00 /bin/bash
root        54  0.0  0.1  34420  2716 pts/0    R+   19:48   0:00 ps -aux
```

```
root@7ca9d9857645:/# ps -aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  9.0  1.4 1074775752 30024 ?    Ssl  19:49   0:02 constellation-node /qdata/constellation/tm.conf -v3
root        30  0.5  0.1  18232  3240 pts/0    Ss   19:49   0:00 /bin/bash
root        47  0.0  0.1  34420  2752 pts/0    R+   19:49   0:00 ps -aux
```

----

After this change:

```
node_2 exited with code 2
node_3 exited with code 2
node_1 exited with code 2
bootnode exited with code 2
constellation_2 exited with code 137
constellation_3 exited with code 137
constellation_1 exited with code 137
```

Not excited about exit code 2s and the 137s on constellation are not great. :/