### PR TITLE
fx: trap SIGTERM, send SIGINT

### DIFF
--- a/geth/start.sh
+++ b/geth/start.sh
@@ -37,4 +37,10 @@ fi
 
 echo "[*] Starting node with args $GETH_ARGS"
 export PRIVATE_CONFIG=/qdata/constellation/tm.conf
-nohup sh -c "geth $GETH_ARGS" 2>>/qdata/logs/geth.log
+geth $GETH_ARGS 2>>/qdata/logs/geth.log &
+pid="$!"
+# Geth wants SIGINT instead of SIGTERM
+trap "kill -INT $pid" SIGTERM
+# Also just forward the SIGKILL when received.
+trap "kill -9 $pid" SIGKILL
+wait $pid


### PR DESCRIPTION
geth expects SIGINT for good shutdown

I saw the logs:

```
INFO [07-30|17:58:29] Got interrupt, shutting down...
INFO [07-30|17:58:29] WebSocket endpoint closed: ws://0.0.0.0:8546
```

```
INFO [07-30|17:59:36] Got interrupt, shutting down...
INFO [07-30|17:59:36] WebSocket endpoint closed: ws://0.0.0.0:8546
DEBUG[07-30|17:59:36] RPC Server shutdown initiatied
INFO [07-30|17:59:36] HTTP endpoint closed: http://0.0.0.0:8545
DEBUG[07-30|17:59:36] RPC Server shutdown initiatied
INFO [07-30|17:59:36] IPC endpoint closed: /qdata/ethereum/geth.ipc
DEBUG[07-30|17:59:36] RPC Server shutdown initiatied
INFO [07-30|17:59:36] Blockchain manager stopped
INFO [07-30|17:59:36] Stopping Ethereum protocol
INFO [07-30|17:59:36] Ethereum protocol stopped
INFO [07-30|17:59:36] Transaction pool stopped
INFO [07-30|17:59:36] Database closed                          database=/qdata/ethereum/geth/chaindata
INFO [07-30|17:59:36] stopping raft protocol handler...
2018-07-30 17:59:36.662089 I | rafthttp: stopping peer 3...
2018-07-30 17:59:36.662402 I | rafthttp: stopped streaming with peer 3 (writer)
DEBUG[07-30|17:59:36] Removing static node                     node="enode://b14f80aabeb05fe03199c3645dbce94522ac897964f1b26fb982835703b04d57df3158ef7ed0d371c53f59141912c4de16765deb09ed2242bb8f5980ce6d0d0c@172.13.0.7:30303?discport=0"
2018-07-30 17:59:36.662736 I | rafthttp: stopped streaming with peer 3 (writer)
INFO [07-30|17:59:36] peer is currently unreachable            peer id=3
INFO [07-30|17:59:36] peer is currently unreachable            peer id=3
INFO [07-30|17:59:36] peer is currently unreachable            peer id=3
INFO [07-30|17:59:36] peer is currently unreachable            peer id=3
INFO [07-30|17:59:36] peer is currently unreachable            peer id=3
INFO [07-30|17:59:36] peer is currently unreachable            peer id=3
2018-07-30 17:59:36.668992 I | rafthttp: stopped HTTP pipelining with peer 3
2018-07-30 17:59:36.669277 I | rafthttp: stopped streaming with peer 3 (stream MsgApp v2 reader)
2018-07-30 17:59:36.669540 I | rafthttp: stopped streaming with peer 3 (stream Message reader)
2018-07-30 17:59:36.669800 I | rafthttp: stopped peer 3
2018-07-30 17:59:36.670738 I | rafthttp: removed peer 3
2018-07-30 17:59:36.670987 I | rafthttp: stopping peer 1...
2018-07-30 17:59:36.671944 I | rafthttp: closed the TCP streaming connection with peer 1 (stream MsgApp v2 writer)
2018-07-30 17:59:36.672201 I | rafthttp: stopped streaming with peer 1 (writer)
2018-07-30 17:59:36.673033 I | rafthttp: closed the TCP streaming connection with peer 1 (stream Message writer)
2018-07-30 17:59:36.673281 I | rafthttp: stopped streaming with peer 1 (writer)
2018-07-30 17:59:36.673533 I | rafthttp: stopped HTTP pipelining with peer 1
2018-07-30 17:59:36.673801 I | rafthttp: stopped streaming with peer 1 (stream MsgApp v2 reader)
2018-07-30 17:59:36.674057 I | rafthttp: stopped streaming with peer 1 (stream Message reader)
2018-07-30 17:59:36.674331 I | rafthttp: stopped peer 1
2018-07-30 17:59:36.674565 I | rafthttp: removed peer 1
DEBUG[07-30|17:59:36] Removing static node                     node="enode://943df4364c439e256461a922c58b338a567069109d019673861b420bfe2af030fe6b27c88f3b7cee293a84cdaa9c20255db96c7c72a60c84b93876152710fb0a@172.13.0.3:30303?discport=0"
INFO [07-30|17:59:36] raft protocol handler stopped
ERROR[07-30|17:59:36] Failed to close database                 database=/qdata/ethereum/geth/chaindata err="leveldb: closed"
INFO [07-30|17:59:36] Raft stopped
DEBUG[07-30|17:59:36] Deleting port mapping                    proto=tcp extport=30303 intport=30303 interface="UPnP or NAT-PMP"
DEBUG[07-30|17:59:36] Read error                               err="accept tcp [::]:30303: use of closed network connection"
DEBUG[07-30|17:59:36] Deleting port mapping                    proto=udp extport=30303 intport=30303 interface="UPnP or NAT-PMP"
DEBUG[07-30|17:59:36] UDP read error                           err="read udp [::]:30303: use of closed network connection"
```

```
INFO [07-30|17:58:52] Got interrupt, shutting down...
```

Not excited about the variety of logs, but at least it's trying to shutdown gracefully.