### PR TITLE
Startup script: pass command as a string to the shell

### DIFF
--- a/geth/start.sh
+++ b/geth/start.sh
@@ -37,8 +37,8 @@ fi
 
 echo "[*] Starting node with args $GETH_ARGS"
 export PRIVATE_CONFIG=/qdata/constellation/tm.conf
-geth $GETH_ARGS 2>>/qdata/logs/geth.log &
-pid="$!"
+sh -c "geth $GETH_ARGS 2>>/qdata/logs/geth.log" &
+pid=$!
 # Geth wants SIGINT instead of SIGTERM
 trap "kill -INT $pid" SIGTERM
 # Also just forward the SIGKILL when received.


### PR DESCRIPTION
changes for cors broke wildcard arguments to wsorigin/cors etc.
restore the method to pass command and args as string to shell